### PR TITLE
Add permission section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ job_id of target workflow jobs
 
 html_url of target workflow jobs
 
+## Permissions
+
+The job using this GitHub Actions must have the `actions:read` permission.
+
 ## Example usage
 
 ### Get current `job_id` URL


### PR DESCRIPTION
https://docs.github.com/en/rest/actions/workflow-jobs#list-jobs-for-a-workflow-run

>GitHub Apps must have the `actions:read` permission to use this endpoint.

I add permission section to README because this GitHub Actions needs `actions:read` permission.