### PR TITLE
Fix unquoted shell variables according to ShellCheck

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,8 +46,7 @@ runs:
         JOBINFO="$(curl --get -Ss -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "${GITHUB_BASEURL}${GITHUB_API}?per_page=${INPUT_PER_PAGE:-30}")"
         echo "${JOBINFO}" | grep "Resource not accessible by integration" &&  exit 1
         TOTAL_COUNT="$(echo "${JOBINFO}" | jq -r .total_count)"
-        eval "$(echo ${JOBINFO} | jq -r --arg job_name "${INPUT_JOB_NAME}" '.jobs | map(select(.name == $job_name)) | .[0] | @sh "JOB_ID=\(.id) HTML_URL=\(.html_url)"')"
-        echo ${JOB_ID} | grep "null" > /dev/null && echo "parse error, job_id is ${JOB_ID} and total_count is ${TOTAL_COUNT}. 'job_name' or 'per_page' might be wrong. See https://github.com/Tiryoh/gha-jobid-action/blob/main/README.md#inputs" && exit 1
-        echo "job_id=${JOB_ID}" >> $GITHUB_OUTPUT
-        echo "html_url=${HTML_URL}" >> $GITHUB_OUTPUT
-
+        eval "$(echo "${JOBINFO}" | jq -r --arg job_name "${INPUT_JOB_NAME}" '.jobs | map(select(.name == $job_name)) | .[0] | @sh "JOB_ID=\(.id) HTML_URL=\(.html_url)"')"
+        echo "${JOB_ID}" | grep "null" > /dev/null && echo "parse error, job_id is ${JOB_ID} and total_count is ${TOTAL_COUNT}. 'job_name' or 'per_page' might be wrong. See https://github.com/Tiryoh/gha-jobid-action/blob/main/README.md#inputs" && exit 1
+        echo "job_id=${JOB_ID}" >> "$GITHUB_OUTPUT"
+        echo "html_url=${HTML_URL}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This is just applying all the fixes suggested by https://www.shellcheck.net/. If you paste the old commands there (and optionally add a `#!/usr/bin/env bash` line at the beginning to get rid of the `Tips depend on target shell and yours is unknown.` message) and click one of the "apply all SC2086" links, you'll end up with the same changes.

See https://github.com/koalaman/shellcheck/wiki/SC2086 for more details.