### PR TITLE
Make token and repository params optional

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,6 +56,45 @@ jobs:
             exit 1
           fi
 
+  single-job-test-default-repo-token:
+    name: Test single job with default repo and token
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          path: .github/actions/gha-jobid-action
+      - name: Run action with options
+        id: test1
+        uses: ./.github/actions/gha-jobid-action
+        with:
+          job_name: "build-matrix (1)"
+          run_id: "6225949607"
+      - name: Verify
+        run: |
+          check_url() {
+            if [[ "$1" == "$2" ]]; then
+              echo "html_url OK"
+            else
+              echo "html_url ERROR" >&2
+              ERROR_FLAG=1
+            fi
+          }
+          check_job_id() {
+            if [[ "$1" == "$2" ]]; then
+              echo "job_id OK"
+            else
+              echo "job_id ERROR" >&2
+              ERROR_FLAG=1
+            fi
+          }
+          ERROR_FLAG=0
+          check_url "${{ steps.test1.outputs.html_url }}" "https://github.com/Tiryoh/gha-jobid-action/actions/runs/6225949607/job/16897423007"
+          check_job_id "${{ steps.test1.outputs.job_id }}" "16897423007"
+          if [[ "$ERROR_FLAG" == 1 ]]; then
+            exit 1
+          fi
+
   multi-jobs-test:
     name: Test multi jobs
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ https://docs.github.com/ja/rest/actions/workflow-jobs?apiVersion=2022-11-28
 
 ### `github_token`
 
-**Required** GITHUB_TOKEN to use GitHub API
+**Optional** auth token to use with GitHub API
 
-Simply, just specify `${{ secrets.GITHUB_TOKEN }}`.
+By default `github.token` context value (same as `secrets.GITHUB_TOKEN`) is used. You can use your own `PAT` if prefered.
+Token requires `actions: read` scope.
 
 ### `job_name`
 
@@ -35,9 +36,9 @@ jobs:
 
 ### `repository`
 
-target GitHub repository
+**Optional**: target GitHub repository
 
-default: `${GITHUB_REPOSITORY}`
+default: `github.repository` context value
 
 ### `run_id`
 
@@ -92,7 +93,6 @@ jobs:
         uses: Tiryoh/gha-jobid-action@v1
         id: jobs
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           job_name: "build" # input job.<job-id>
           #job_name: "${{ github.job }}"  # if job.<job-id>.name is not specified, this works too
       - name: Output Current Job Log URL
@@ -121,7 +121,6 @@ jobs:
         uses: Tiryoh/gha-jobid-action@v1
         id: jobs
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           job_name: "Build and Test" # input job.<job-id>.name here. job.<job-id> won't works.
       - name: Output Current Job Log URL
         run: echo ${{ steps.jobs.outputs.html_url }}
@@ -151,7 +150,6 @@ jobs:
         uses: Tiryoh/gha-jobid-action@v1
         id: jobs
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           job_name: "build (${{ matrix.distro }})" # input job.<job-id>.name and matrix here.
           per_page: 50 # input matrix size here if it is larger than 30
       - name: Output Current Job Log URL

--- a/action.yml
+++ b/action.yml
@@ -12,12 +12,14 @@ inputs:
   run_id:
     description: "run_id of target workflow run"
     required: false
+    default: ${{ github.run_id }}
   job_name:
     description: "job_name of tartget workflow jobs"
     required: true
   per_page:
     description: "Results per page (max 100) of target workflow run"
     required: false
+    default: 30
 outputs:
   job_id:
     description: "job_id of target workflow jobs"
@@ -41,11 +43,10 @@ runs:
         INPUT_RUN_ID: ${{ inputs.run_id }}
         INPUT_JOB_NAME: ${{ inputs.job_name }}
         INPUT_PER_PAGE: ${{ inputs.per_page }}
-        GITHUB_BASEURL: ${{ github.api_url }}
       shell: bash
       run: |
-        GITHUB_API="/repos/${INPUT_REPOSITORY:-${GITHUB_REPOSITORY}}/actions/runs/${INPUT_RUN_ID:-${GITHUB_RUN_ID}}/jobs"
-        JOBINFO="$(curl --get -Ss -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "${GITHUB_BASEURL}${GITHUB_API}?per_page=${INPUT_PER_PAGE:-30}")"
+        GITHUB_API="/repos/${INPUT_REPOSITORY}/actions/runs/${INPUT_RUN_ID}/jobs"
+        JOBINFO="$(curl --get -Ss -H "Authorization: Bearer ${INPUT_GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "${GITHUB_API_URL}${GITHUB_API}?per_page=${INPUT_PER_PAGE}")"
         echo "${JOBINFO}" | grep "Resource not accessible by integration" &&  exit 1
         TOTAL_COUNT="$(echo "${JOBINFO}" | jq -r .total_count)"
         eval "$(echo "${JOBINFO}" | jq -r --arg job_name "${INPUT_JOB_NAME}" '.jobs | map(select(.name == $job_name)) | .[0] | @sh "JOB_ID=\(.id) HTML_URL=\(.html_url)"')"

--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,12 @@ description: "GitHub Action to get the current workflow run's job_id"
 inputs:
   github_token:
     description: "GITHUB_TOKEN to use GitHub API v3"
-    required: true
+    required: false
+    default: ${{ github.token }}
   repository:
     description: "target GitHub repository"
     required: false
+    default: ${{ github.repository }}
   run_id:
     description: "run_id of target workflow run"
     required: false


### PR DESCRIPTION
In majority of use cases of this action, it is working on current workflow run repository and use default GH actions token. Would be nice if those parameters were optional and taken from `github` context by default.